### PR TITLE
Fix: add missing .meta file

### DIFF
--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 94bfd84c3a1858455a5efa2fa611216e
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
My Unity complains about the missing .meta file for LISENCE.md : 

`Asset Packages/com.gabrielbigardi.savesystem/LICENSE.md has no meta file, but it's in an immutable folder. The asset will be ignored.
`

Just created one. 